### PR TITLE
Compiling Error Fix

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2355,26 +2355,26 @@
 #define PREHEAT_2_LABEL         "PETG"
 #define PREHEAT_2_TEMP_HOTEND   235
 #define PREHEAT_2_TEMP_BED       80
-//#define PREHEAT_2_TEMP_CHAMBER   35
-//#define PREHEAT_2_FAN_SPEED       0 // Value from 0 to 255
+#define PREHEAT_2_TEMP_CHAMBER   35
+#define PREHEAT_2_FAN_SPEED       0 // Value from 0 to 255
 
 #define PREHEAT_3_LABEL         "Nylon"
 #define PREHEAT_3_TEMP_HOTEND   245
 #define PREHEAT_3_TEMP_BED       65
-//#define PREHEAT_3_TEMP_CHAMBER   35
-//#define PREHEAT_3_FAN_SPEED       0 // Value from 0 to 255
+#define PREHEAT_3_TEMP_CHAMBER   35
+#define PREHEAT_3_FAN_SPEED       0 // Value from 0 to 255
 
 #define PREHEAT_4_LABEL         "Hotend Cleaning"
 #define PREHEAT_4_TEMP_HOTEND   120
-//#define PREHEAT_4_TEMP_BED        0
-//#define PREHEAT_4_TEMP_CHAMBER    0
-//#define PREHEAT_4_FAN_SPEED       0 // Value from 0 to 255
+#define PREHEAT_4_TEMP_BED        0
+#define PREHEAT_4_TEMP_CHAMBER    0
+#define PREHEAT_4_FAN_SPEED       0 // Value from 0 to 255
 
 #define PREHEAT_5_LABEL         "Nozzle Tightening"
 #define PREHEAT_5_TEMP_HOTEND   260
-//#define PREHEAT_5_TEMP_BED        0
-//#define PREHEAT_5_TEMP_CHAMBER    0
-//#define PREHEAT_5_FAN_SPEED       0 // Value from 0 to 255
+#define PREHEAT_5_TEMP_BED        0
+#define PREHEAT_5_TEMP_CHAMBER    0
+#define PREHEAT_5_FAN_SPEED       0 // Value from 0 to 255
 
 // @section motion
 


### PR DESCRIPTION
Re-enabled the Preheat Constant settings that I don't need because they were causing compiling errors because they weren't defined.

This fix was successful in compiling, but did require updating Arduino IDE to do so due to an error claiming the file path to the Anet 1.0 board was too long.
