### PR TITLE
Temperature Menu at the Top

### DIFF
--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -41,7 +41,7 @@
  * here we define this default string as the date where the latest release
  * version was tagged.
  */
-//#define STRING_DISTRIBUTION_DATE "2023-04-26"
+//#define STRING_DISTRIBUTION_DATE "2023-04-27"
 
 /**
  * Defines a generic printer name to be output to the LCD after booting Marlin.

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -243,6 +243,10 @@ void menu_main() {
   START_MENU();
   BACK_ITEM(MSG_INFO_SCREEN);
 
+  #if HAS_TEMPERATURE
+    SUBMENU(MSG_TEMPERATURE, menu_temperature);
+  #endif
+
   #if HAS_MEDIA && !defined(MEDIA_MENU_AT_TOP) && !HAS_ENCODER_WHEEL
     #define MEDIA_MENU_AT_TOP
   #endif
@@ -332,10 +336,6 @@ void menu_main() {
 
   #if HAS_CUTTER
     SUBMENU(MSG_CUTTER(MENU), STICKY_SCREEN(menu_spindle_laser));
-  #endif
-
-  #if HAS_TEMPERATURE
-    SUBMENU(MSG_TEMPERATURE, menu_temperature);
   #endif
 
   #if HAS_POWER_MONITOR

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -164,6 +164,14 @@ void menu_temperature() {
   START_MENU();
   BACK_ITEM(MSG_MAIN_MENU);
 
+  #if HAS_TEMP_HOTEND || HAS_HEATED_BED
+    //
+    // Cooldown
+    //
+    if (TERN0(HAS_HEATED_BED, thermalManager.degTargetBed())) has_heat = true;
+    if (has_heat) ACTION_ITEM(MSG_COOLDOWN, lcd_cooldown);
+  #endif
+
   //
   // Nozzle:
   // Nozzle [1-5]:
@@ -274,14 +282,6 @@ void menu_temperature() {
         ACTION_ITEM_f(ui.get_preheat_label(m), MSG_PREHEAT_M, do_preheat_end_m);
       #endif
     }
-  #endif
-
-  #if HAS_TEMP_HOTEND || HAS_HEATED_BED
-    //
-    // Cooldown
-    //
-    if (TERN0(HAS_HEATED_BED, thermalManager.degTargetBed())) has_heat = true;
-    if (has_heat) ACTION_ITEM(MSG_COOLDOWN, lcd_cooldown);
   #endif
 
   END_MENU();

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -172,6 +172,20 @@ void menu_temperature() {
     if (has_heat) ACTION_ITEM(MSG_COOLDOWN, lcd_cooldown);
   #endif
 
+  #if HAS_PREHEAT
+    //
+    // Preheat for all Materials
+    //
+    LOOP_L_N(m, PREHEAT_COUNT) {
+      editable.int8 = m;
+      #if HAS_MULTI_HOTEND || HAS_HEATED_BED
+        SUBMENU_f(ui.get_preheat_label(m), MSG_PREHEAT_M, menu_preheat_m);
+      #elif HAS_HOTEND
+        ACTION_ITEM_f(ui.get_preheat_label(m), MSG_PREHEAT_M, do_preheat_end_m);
+      #endif
+    }
+  #endif
+
   //
   // Nozzle:
   // Nozzle [1-5]:
@@ -269,20 +283,6 @@ void menu_temperature() {
     #endif
 
   #endif // HAS_FAN
-
-  #if HAS_PREHEAT
-    //
-    // Preheat for all Materials
-    //
-    LOOP_L_N(m, PREHEAT_COUNT) {
-      editable.int8 = m;
-      #if HAS_MULTI_HOTEND || HAS_HEATED_BED
-        SUBMENU_f(ui.get_preheat_label(m), MSG_PREHEAT_M, menu_preheat_m);
-      #elif HAS_HOTEND
-        ACTION_ITEM_f(ui.get_preheat_label(m), MSG_PREHEAT_M, do_preheat_end_m);
-      #endif
-    }
-  #endif
 
   END_MENU();
 }


### PR DESCRIPTION
These changes close #3.

The Temperature Menu has been moved to the top of the Main Menu, and the Cooldown and Preheat menu items have been moved to the top of the Temperature Menu. This returns the format to more like I had it with Marlin 1.1.9.1, but I tested all the Preheat settings, and they actually work this time.

It should be noted that the "Cleaning" and "Tightening" menus do not change the bed temperature if it has been previously set, but I don't foresee that being a problem for me.